### PR TITLE
Axios 0.18.1 - No errrors on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "aes256": "^1.0.3",
     "autoprefixer": "^7.2.6",
-    "axios": "ˆ0.18.1",
+    "axios": "0.18.1",
     "babel-core": "^6.26.3",
     "babel-loader": "^7.1.4",
     "babel-plugin-transform-runtime": "^6.22.0",


### PR DESCRIPTION
Just change the version to a static version for the npm install.